### PR TITLE
Specify Python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
 	author='Jacob Schreiber',
 	author_email='jmschreiber91@gmail.com',
 	packages=['modiscolite'],
+	python_requires='>=3.7, <=3.10',
 	scripts=['modisco'],
 	url='https://github.com/jmschrei/tfmodisco-lite',
 	license='LICENSE.txt',


### PR DESCRIPTION
Tested on 3.6, 3.7, 3.10, and 3.11. Numba requires a version from 3.7 to 3.10 as stated [here](https://numba.readthedocs.io/en/stable/user/installing.html).