### PR TITLE
Update Python version req to include 3.10.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
 	author='Jacob Schreiber',
 	author_email='jmschreiber91@gmail.com',
 	packages=['modiscolite'],
-	python_requires='>=3.7, <=3.10',
+	python_requires='>=3.7, <3.11',
 	scripts=['modisco'],
 	url='https://github.com/jmschrei/tfmodisco-lite',
 	license='LICENSE.txt',


### PR DESCRIPTION
Changing the `<=3.10` req to `<3.11` to include 3.10.x versions of Python.