### PR TITLE
(READY) Make motif database-based reporting optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,15 @@ Release History
 ===============
 
 
+Version 2.1.0
+==============
+
+modisco
+-------
+	
+	- Make motif database-based reporting optional.
+	- Require Python 3.7.x to 3.10.x.
+
 Version 2.0.7
 ==============
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ where `[...]` denotes that data is stored at that attribute. Importantly, the se
 
 #### Generating reports
 
-`modisco report -i modisco_results.h5 -o report/ -s report/ -m motifs.txt`
+Basic reporting can be executed with the following command:  
+```sh
+modisco report -i modisco_results.h5 -o report/ -s report/
+```
+
+You may also generate reports compared to a given database of motifs with the following command:  
+```sh
+modisco report -i modisco_results.h5 -o report/ -s report/ -m motifs.txt
+```
 
 This command will take the results from the tfmodisco-lite run, as well as a reference database of motifs to compare the extracted patterns to, and generate a HTML report like the one seen above. Each pattern that is extracted by tfmodisco-lite is compared against the database of motifs using [TOMTOM](https://meme-suite.org/meme/tools/tomtom) to match them with prior knowledge.

--- a/modisco
+++ b/modisco
@@ -44,7 +44,7 @@ report_parser.add_argument("-o", "--output", type=str, required=True,
 	help="A directory to put the output results including the html report.")
 report_parser.add_argument("-s", "--suffix", type=str, default="./",
 	help="The suffix to add to the beginning of images. Should be equal to the output if using a Jupyter notebook.")
-report_parser.add_argument("-m", "--meme_db", type=str, required=True,
+report_parser.add_argument("-m", "--meme_db", type=str, required=False,
 	help="A MEME file containing motifs.")
 report_parser.add_argument("-n", "--n_matches", type=int, default=3,
 	help="The number of top TOMTOM matches to include in the report.")

--- a/modisco
+++ b/modisco
@@ -44,7 +44,7 @@ report_parser.add_argument("-o", "--output", type=str, required=True,
 	help="A directory to put the output results including the html report.")
 report_parser.add_argument("-s", "--suffix", type=str, default="./",
 	help="The suffix to add to the beginning of images. Should be equal to the output if using a Jupyter notebook.")
-report_parser.add_argument("-m", "--meme_db", type=str, required=False,
+report_parser.add_argument("-m", "--meme_db", type=str, default=None,
 	help="A MEME file containing motifs.")
 report_parser.add_argument("-n", "--n_matches", type=int, default=3,
 	help="The number of top TOMTOM matches to include in the report.")
@@ -125,8 +125,8 @@ if args.cmd == "motifs":
 	modiscolite.io.save_hdf5(args.output, pos_patterns, neg_patterns)
 
 elif args.cmd == 'report':
-	modiscolite.report.report_motifs(args.h5py, args.output, suffix=args.suffix, 
-		top_n_matches=args.n_matches, meme_motif_db=args.meme_db)
+	modiscolite.report.report_motifs(args.h5py, args.output, img_path_suffix=args.suffix, meme_motif_db=args.meme_db, 
+		top_n_matches=args.n_matches)
 
 elif args.cmd == 'convert':
 	modiscolite.io.convert(args.h5py, args.output)

--- a/modiscolite/report.py
+++ b/modiscolite/report.py
@@ -216,7 +216,7 @@ def create_modisco_logos(modisco_file, modisco_logo_dir, trim_threshold):
 
 	return tags
 
-def report_motifs(modisco_h5py, output_dir, meme_motif_db, suffix='./', 
+def report_motifs(modisco_h5py, output_dir, meme_motif_db: os.PathLike=None, suffix='./', 
 	top_n_matches=3, trim_threshold=0.3, trim_min_length=3):
 
 	if not os.path.isdir(output_dir):
@@ -226,8 +226,13 @@ def report_motifs(modisco_h5py, output_dir, meme_motif_db, suffix='./',
 		os.mkdir(output_dir + '/trimmed_logos/')
 	modisco_logo_dir = output_dir + '/trimmed_logos/'
 
-	motifs = read_meme(meme_motif_db)
 	names = create_modisco_logos(modisco_h5py, modisco_logo_dir, trim_threshold)
+
+	# If no meme motif file is provided, skip the TOMTOM comparison step.
+	if meme_motif_db is None:
+		return
+
+	motifs = read_meme(meme_motif_db)
 
 	tomtom_df = run_tomtom(modisco_h5py, output_dir, meme_motif_db, 
 		top_n_matches=top_n_matches, tomtom_exec="tomtom", 

--- a/modiscolite/report.py
+++ b/modiscolite/report.py
@@ -155,6 +155,7 @@ def path_to_image_html(path):
 	return '<img src="'+ path + '" width="240" >'
 
 def _plot_weights(array, path, figsize=(10,3)):
+	"""Plot weights as a sequence logo and save to file."""
 	fig = plt.figure(figsize=figsize)
 	ax = fig.add_subplot(111) 
 
@@ -180,6 +181,7 @@ def make_logo(match, logo_dir, motifs):
 		
 
 def create_modisco_logos(modisco_h5py: os.PathLike, modisco_logo_dir, trim_threshold, pattern_groups: List[str]):
+	"""Open a modisco results file and create and write logos to file for each pattern."""
 	modisco_results = h5py.File(modisco_h5py, 'r')
 
 	tags = []

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
 	name='modisco-lite',
-	version='2.0.7',
+	version='2.1.0',
 	author='Jacob Schreiber',
 	author_email='jmschreiber91@gmail.com',
 	packages=['modiscolite'],


### PR DESCRIPTION
- Fixes #5 
- Now when a motif database is provided, the report with the TOMTOM comparison will be written to `motifs.tomtom.html`
