### PR TITLE
(WIP) Implement MEME output subcommand `meme`

### DIFF
--- a/modisco
+++ b/modisco
@@ -9,6 +9,7 @@ import modiscolite
 
 import numpy as np
 
+
 desc = """TF-MoDISco is a motif detection algorithm that takes in nucleotide
 	sequence and the attributions from a neural network model and return motifs
 	that are repeatedly enriched for attriution score across the examples.
@@ -17,7 +18,7 @@ desc = """TF-MoDISco is a motif detection algorithm that takes in nucleotide
 
 # Read in the arguments
 parser = argparse.ArgumentParser(description=desc)
-subparsers = parser.add_subparsers(help="Must be either 'motifs', 'report', or 'convert'.", required=True, dest='cmd')
+subparsers = parser.add_subparsers(help="Must be either 'motifs', 'report', 'convert', 'convert-backward', or 'meme'.", required=True, dest='cmd')
 
 motifs_parser = subparsers.add_parser("motifs", help="Run TF-MoDISco and extract the motifs.")
 motifs_parser.add_argument("-s", "--sequences", type=str,
@@ -61,6 +62,21 @@ convertback_parser.add_argument("-i", "--h5py", type=str, required=True,
 convertback_parser.add_argument("-o", "--output", type=str, required=True,
 	help="An HDF5 file formatted in the old way.")
 
+meme_parser = subparsers.add_parser("meme", help="Create a MEME file from a modisco results file.", formatter_class=argparse.RawTextHelpFormatter)
+meme_parser.add_argument("-i", "--h5py", type=str, required=True,
+	help="An HDF5 file containing the output from modiscolite.")
+meme_parser.add_argument("-t", "--datatype", type=modiscolite.util.case_insensitive_meme_datatype, choices=list(modiscolite.util.MemeDataType), required=True,
+	help="""A case-insensitive string specifying the desired data of the output file.,
+The options are as follows:
+- 'PFM':      The position-frequency matrix.
+- 'CWM':      The contribution-weight matrix.
+- 'hCWM':     The hypothetical contribution-weight matrix; hypothetical
+              contribution scores are the contributions of nucleotides not encoded
+              by the one-hot encoding sequence. 
+- 'CWM-PFM':  The softmax of the contribution-weight matrix.
+- 'hCWM-PFM': The softmax of the hypothetical contribution-weight matrix."""
+)
+meme_parser.add_argument("-o", "--output", type=str, help="The path to the output file.")
 
 # Pull the arguments
 args = parser.parse_args()
@@ -123,6 +139,9 @@ if args.cmd == "motifs":
 		verbose=args.verbose)
 
 	modiscolite.io.save_hdf5(args.output, pos_patterns, neg_patterns)
+
+elif args.cmd == 'meme':
+	modiscolite.io.write_meme(args.h5py, args.datatype)
 
 elif args.cmd == 'report':
 	modiscolite.report.report_motifs(args.h5py, args.output, img_path_suffix=args.suffix, meme_motif_db=args.meme_db, 

--- a/modisco
+++ b/modisco
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # tf-modisco command-line tool
-# Author: Jacob Schreiber <jmschreiber91@gmail.com>
+# Author: Jacob Schreiber <jmschreiber91@gmail.com>, Ivy Raine <ivy.ember.raine@gmail.com>
 
 import h5py
 import hdf5plugin

--- a/modisco
+++ b/modisco
@@ -141,7 +141,7 @@ if args.cmd == "motifs":
 	modiscolite.io.save_hdf5(args.output, pos_patterns, neg_patterns)
 
 elif args.cmd == 'meme':
-	modiscolite.io.write_meme(args.h5py, args.datatype)
+	modiscolite.io.write_meme_from_h5(args.h5py, args.datatype, args.output)
 
 elif args.cmd == 'report':
 	modiscolite.report.report_motifs(args.h5py, args.output, img_path_suffix=args.suffix, meme_motif_db=args.meme_db, 

--- a/modisco
+++ b/modisco
@@ -65,8 +65,8 @@ convertback_parser.add_argument("-o", "--output", type=str, required=True,
 meme_parser = subparsers.add_parser("meme", help="Create a MEME file from a modisco results file.", formatter_class=argparse.RawTextHelpFormatter)
 meme_parser.add_argument("-i", "--h5py", type=str, required=True,
 	help="An HDF5 file containing the output from modiscolite.")
-meme_parser.add_argument("-t", "--datatype", type=modiscolite.util.case_insensitive_meme_datatype, choices=list(modiscolite.util.MemeDataType), required=True,
-	help="""A case-insensitive string specifying the desired data of the output file.,
+meme_parser.add_argument("-t", "--datatype", type=modiscolite.util.MemeDataType, choices=list(modiscolite.util.MemeDataType), required=True,
+	help="""A case-sensitive string specifying the desired data of the output file.,
 The options are as follows:
 - 'PFM':      The position-frequency matrix.
 - 'CWM':      The contribution-weight matrix.

--- a/modiscolite/__init__.py
+++ b/modiscolite/__init__.py
@@ -8,5 +8,6 @@ from . import util
 from . import tfmodisco
 from . import cluster
 from . import report
+from . import meme_writer
 
 __version__ = '2.0.7'

--- a/modiscolite/io.py
+++ b/modiscolite/io.py
@@ -176,7 +176,7 @@ def write_meme_from_h5(filename: os.PathLike, datatype: util.MemeDataType, outpu
 		The name of the MEME file to write.
 	"""
 
-	writer = meme_writer.MemeWriter(
+	writer = meme_writer.MEMEWriter(
 		memesuite_version='5',
 		alphabet='ACGT',
 		background_frequencies='A 0.25 C 0.25 G 0.25 T 0.25'
@@ -201,7 +201,7 @@ def write_meme_from_h5(filename: os.PathLike, datatype: util.MemeDataType, outpu
 			else:
 				raise ValueError("Unknown datatype: {}".format(datatype))
 
-			motif = meme_writer.MemeWriterMotif(
+			motif = meme_writer.MEMEWriterMotif(
 						name=name,
 						probability_matrix=probability_matrix,
 						alphabet_length=4,

--- a/modiscolite/io.py
+++ b/modiscolite/io.py
@@ -7,6 +7,7 @@ import h5py
 import hdf5plugin
 
 import numpy as np
+import scipy
 
 from . import util
 from . import meme_writer
@@ -194,10 +195,10 @@ def write_meme_from_h5(filename: os.PathLike, datatype: util.MemeDataType, outpu
 				probability_matrix = datasets['hypothetical_contribs'][:]
 			elif datatype == util.MemeDataType.CWM_PFM:
 				# Softmax version of CWM.
-				probability_matrix = np.exp(datasets['contrib_scores'][:]) / np.sum(np.exp(datasets['contrib_scores'][:]), axis=1, keepdims=True)
+				probability_matrix = scipy.special.softmax(datasets['contrib_scores'][:], axis=1)
 			elif datatype == util.MemeDataType.hCWM_PFM:
 				# Softmax version of hCWM.
-				probability_matrix = np.exp(datasets['hypothetical_contribs'][:]) / np.sum(np.exp(datasets['hypothetical_contribs'][:]), axis=1, keepdims=True)
+				probability_matrix = scipy.special.softmax(datasets['hypothetical_contribs'][:], axis=1)
 			else:
 				raise ValueError("Unknown datatype: {}".format(datatype))
 
@@ -212,7 +213,7 @@ def write_meme_from_h5(filename: os.PathLike, datatype: util.MemeDataType, outpu
 	new_output_filename = output_filename
 	if output_filename is None:
 		file_without_extension = os.path.splitext(filename)[0]
-		new_output_filename = os.Path(f'{file_without_extension}.{datatype.name}.meme')
+		new_output_filename = f'{file_without_extension}.{datatype.name}.meme'
 	writer.write(new_output_filename)
 
 

--- a/modiscolite/io.py
+++ b/modiscolite/io.py
@@ -1,5 +1,5 @@
 # io.py
-# Authors: Jacob Schreiber <jmschreiber91@gmail.com>
+# Authors: Jacob Schreiber <jmschreiber91@gmail.com>, Ivy Raine <ivy.ember.raine@gmail.com>
 
 import os
 

--- a/modiscolite/io.py
+++ b/modiscolite/io.py
@@ -177,9 +177,10 @@ def write_meme_from_h5(filename: os.PathLike, datatype: util.MemeDataType, outpu
 		The name of the MEME file to write.
 	"""
 
+	alphabet = 'ACGT'
 	writer = meme_writer.MEMEWriter(
 		memesuite_version='5',
-		alphabet='ACGT',
+		alphabet=alphabet,
 		background_frequencies='A 0.25 C 0.25 G 0.25 T 0.25'
 	)
 
@@ -205,8 +206,8 @@ def write_meme_from_h5(filename: os.PathLike, datatype: util.MemeDataType, outpu
 			motif = meme_writer.MEMEWriterMotif(
 						name=name,
 						probability_matrix=probability_matrix,
-						alphabet_length=4,
-						source_sites=1)
+						source_sites=1,
+						alphabet_length=4)
 
 			writer.add_motif(motif)
 	

--- a/modiscolite/io.py
+++ b/modiscolite/io.py
@@ -207,6 +207,7 @@ def write_meme_from_h5(filename: os.PathLike, datatype: util.MemeDataType, outpu
 						name=name,
 						probability_matrix=probability_matrix,
 						source_sites=1,
+						alphabet=alphabet,
 						alphabet_length=4)
 
 			writer.add_motif(motif)

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -6,15 +6,31 @@ import numpy as np
 from os import PathLike
 
 class MEMEWriterMotif:
-	"""Class for handling Motif for MEME file writing."""
+	"""Class for handling Motif for MEME file writing.
+	
+	Parameters
+	----------
+	name : str
+		The name of the motif.
+	probability_matrix : np.ndarray
+		The probability matrix of the motif.
+	alphabet : str
+		The alphabet of the motif. Used in calculating the alphabet length.
+		However, it does not work with custom alphabets currently. 
+	alphabet_length : Optional[int]
+		The length of the alphabet. Also known as 'alength' in MEME Suite.
+	source_sites : int
+		The number of source sites. Also known as 'nsites' in MEME Suite.
+	e_value : Optional[str]
+		The E-value of the motif.
+	url : Optional[str]
+		The URL of the motif.
+	"""
 
 	def __init__(
 		self,
 		name: str,
 		probability_matrix: np.ndarray,
-		# `alphabet_length` is known as 'alength' in MEME Suite.
-		alphabet_length: int,
-		# `source_sites` is known as 'nsites' in MEME Suite.
 		source_sites: int,
 		alphabet: str,
 		alphabet_length: Optional[int] = None,
@@ -67,28 +83,43 @@ letter-probability matrix: alength= {str(self.alphabet_length)} w= {self.probabi
 
 
 class MEMEWriter:
-	"""Class for handling MEME file writing."""
+	"""Class for writing MEME files based on MEME Suite specifications, from
+	user-provided motifs.
+	
+	Parameters
+	----------
+	memesuite_version : str
+		The version of MEME Suite used to create the file.
+		May also be added incrementally using `add_motif()`.
+	motifs : List[MEMEWriterMotif]
+		The motifs to be written to the file.
+	alphabet : Optional[str]
+		The alphabet of the motifs. Optional but recommended.
+		Example: "ACGT".
+	background_frequencies : Optional[str]
+		The background frequencies of the motifs.
+		Example: "A 0.25 C 0.25 G 0.25 T 0.25".
+	background_frequencies_source : Optional[str]
+		The source of the background frequencies.
+	strands : Optional[List[str]]
+		The strands of the motifs. Optional.
+		Example: "+ -".
+	"""
 
 	def __init__(
 		self,
 		memesuite_version: str,
-		# May also be added incrementally using `add_motif()`.
 		motifs: List[MEMEWriterMotif] = [],
-		# Optional (Recommended) by MEME Suite.
 		alphabet: Optional[str] = None,
 		background_frequencies: Optional[str] = None,
 		background_frequencies_source: Optional[str] = None,
-		# Optional by MEME Suite.
 		strands: Optional[List[str]] = None,
 	) -> None:
 		self._memesuite_version = memesuite_version
 		self._motifs = motifs if motifs is not None else []
-		# Alphabet example: "ACGT".
 		self._alphabet = alphabet
-		# Background frequncies example: "A 0.25 C 0.25 G 0.25 T 0.25".
 		self._background_frequencies = background_frequencies
 		self._background_frequencies_source = background_frequencies_source
-		# Strands example: "+ -".
 		self._strands = strands
 
 	@property

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -1,4 +1,5 @@
 # Create a class that can be used to write MEME files.
+# Authors: Ivy Raine <ivy.ember.raine@gmail.com>, Jacob Schreiber <jmschreiber91@gmail.com>
 from typing import List, Optional
 import numpy as np
 

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -37,39 +37,15 @@ class MEMEWriterMotif:
 		e_value: Optional[str] = None,
 		url: Optional[str] = None
 	) -> None:
-		self._name = name
-		self._probability_matrix = probability_matrix
-		self._source_sites = source_sites
-		self._alphabet_length = len(alphabet) if alphabet_length is None else alphabet_length
-		self._e_value = e_value
-		self._url = url
-
-	@property
-	def name(self):
-		return self._name
-
-	@property
-	def probability_matrix(self):
-		return self._probability_matrix
-
-	@property
-	def alphabet_length(self):
-		return self._alphabet_length
-	
-	@property
-	def source_sites(self):
-		return self._source_sites
-
-	@property
-	def e_value(self):
-		return self._e_value
-
-	@property
-	def url(self):
-		return self._url
+		self.name = name
+		self.probability_matrix = probability_matrix
+		self.source_sites = source_sites
+		self.alphabet_length = len(alphabet) if alphabet_length is None else alphabet_length
+		self.e_value = e_value
+		self.url = url
 
 	def __repr__(self) -> str:
-		return f"MEMEWriterMotif(name={self._name})"
+		return f"MEMEWriterMotif(name={self.name})"
 
 	def __str__(self) -> str:
 		output = (f'''\
@@ -115,55 +91,31 @@ class MEMEWriter:
 		background_frequencies_source: Optional[str] = None,
 		strands: Optional[List[str]] = None,
 	) -> None:
-		self._memesuite_version = memesuite_version
-		self._motifs = motifs if motifs is not None else []
-		self._alphabet = alphabet
-		self._background_frequencies = background_frequencies
-		self._background_frequencies_source = background_frequencies_source
-		self._strands = strands
-
-	@property
-	def memesuite_version(self):
-		return self._memesuite_version
-
-	@property
-	def motifs(self):
-		return self._motifs
-	
-	@property
-	def alphabet(self):
-		return self._alphabet
-	
-	@property
-	def background_frequencies(self):
-		return self._background_frequencies
-
-	@property
-	def background_frequencies_source(self):
-		return self._background_frequencies_source
-	
-	@property
-	def strands(self):
-		return self._strands
+		self.memesuite_version = memesuite_version
+		self.motifs = motifs if motifs is not None else []
+		self.alphabet = alphabet
+		self.background_frequencies = background_frequencies
+		self.background_frequencies_source = background_frequencies_source
+		self.strands = strands
 
 	def add_motif(self, motif: MEMEWriterMotif) -> None:
-		self._motifs.append(motif)
+		self.motifs.append(motif)
 
 	def write(self, file_path: PathLike) -> None:
 
 		output = ""
-		output += f"MEME version {self._memesuite_version}\n\n"
-		if self._alphabet:
-			output += f"ALPHABET= {self._alphabet}\n\n"
-		if self._strands:
-			output += f"strands: {self._strands}\n\n"
-		if self._background_frequencies:
+		output += f"MEME version {self.memesuite_version}\n\n"
+		if self.alphabet:
+			output += f"ALPHABET= {self.alphabet}\n\n"
+		if self.strands:
+			output += f"strands: {self.strands}\n\n"
+		if self.background_frequencies:
 			output += f"Background letter frequencies"
-			if self._background_frequencies_source:
-				output += f" (from {self._background_frequencies_source}):"
+			if self.background_frequencies_source:
+				output += f" (from {self.background_frequencies_source}):"
 			output += "\n"
-			output += f"{self._background_frequencies}\n\n"
-		for motif in self._motifs:
+			output += f"{self.background_frequencies}\n\n"
+		for motif in self.motifs:
 			output += str(motif)
 			output += "\n\n"
 		try:
@@ -174,9 +126,8 @@ class MEMEWriter:
 		except IOError:
 			print(f"An error occurred while writing to the file {file_path}")
 	
-
 	def __repr__(self) -> str:
-		return f"MEMEWriter(memesuite_version={self._memesuite_version}, motifs={self._motifs}, alphabet={self._alphabet}, background_frequencies={self._background_frequencies}, strands={self._strands})"
+		return f"MEMEWriter(memesuite_version={self.memesuite_version}, motifs={self.motifs}, alphabet={self.alphabet}, background_frequencies={self.background_frequencies}, strands={self.strands})"
 
 
 def array_to_string(array: np.ndarray, precision: int) -> str:

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -16,13 +16,15 @@ class MEMEWriterMotif:
 		alphabet_length: int,
 		# `source_sites` is known as 'nsites' in MEME Suite.
 		source_sites: int,
+		alphabet: str,
+		alphabet_length: Optional[int] = None,
 		e_value: Optional[str] = None,
 		url: Optional[str] = None
 	) -> None:
 		self._name = name
 		self._probability_matrix = probability_matrix
-		self._alphabet_length = alphabet_length
 		self._source_sites = source_sites
+		self._alphabet_length = len(alphabet) if alphabet_length is None else alphabet_length
 		self._e_value = e_value
 		self._url = url
 

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -138,7 +138,6 @@ class MemeWriter:
 			with open(file_path, "w") as file:
 				# Write the string to the file
 				file.write(output)
-			print(f"Successfully wrote to the file {file_path}")
 		except IOError:
 			print(f"An error occurred while writing to the file {file_path}")
 	

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -53,6 +53,16 @@ class MemeWriterMotif:
 	def __repr__(self) -> str:
 		return f"MemeWriterMotif(name={self._name})"
 
+	def __str__(self) -> str:
+		output = (f'''\
+MOTIF {self.name}
+letter-probability matrix: alength= {str(self.alphabet_length)} w= {self.probability_matrix.shape[0]} nsites= {str(self.source_sites)}{f"E= {self.e_value}" if self.e_value is not None else ""}
+{array_to_string(self.probability_matrix, 6)}''')
+		if self.url is not None:
+			output += f"URL {self.url}"	
+		return output
+
+
 
 class MemeWriter:
 	"""Class for handling MEME file writing."""
@@ -108,17 +118,6 @@ class MemeWriter:
 
 	def write(self, file_path: PathLike) -> None:
 
-		def array_to_string(array: np.ndarray, precision: int) -> str:
-			"""Convert a 2D numpy array to a string with the given precision."""
-			# create a format string with the desired precision
-			float_formatter = "{:." + str(precision) + "f}"
-			
-			# manually format each float in the array and join them with spaces
-			string_rows = [" ".join(float_formatter.format(x) for x in row) for row in array]
-
-			# join rows with line breaks to retain 2D structure
-			return "\n".join(string_rows)
-
 		output = ""
 		output += f"MEME version {self._memesuite_version}\n\n"
 		if self._alphabet:
@@ -132,26 +131,29 @@ class MemeWriter:
 			output += "\n"
 			output += f"{self._background_frequencies}\n\n"
 		for motif in self._motifs:
-			output += f"MOTIF {motif.name}\n"
-			output += f"letter-probability matrix: alength= {str(motif.alphabet_length)} w= {motif.probability_matrix.shape[0]} nsites= {str(motif.source_sites)}"
-			if motif.e_value:
- 				output += f"E= {motif.e_value}"
-			output += "\n"
-			# Iterate through rows in nparray
-			output += array_to_string(motif.probability_matrix, 6)
-			output += "\n"
-			if motif.url:
-				output += f"URL {motif.url}\n"
-			output += "\n"
+			output += str(motif)
+			output += "\n\n"
 		try:
 			# Open the file in write mode
 			with open(file_path, "w") as file:
 				# Write the string to the file
 				file.write(output)
-			print(f"Successfully wrote to the file {file_path}.")
+			print(f"Successfully wrote to the file {file_path}")
 		except IOError:
-			print(f"An error occurred while writing to the file {file_path}.")
+			print(f"An error occurred while writing to the file {file_path}")
 	
 
 	def __repr__(self) -> str:
 		return f"MemeWriter(memesuite_version={self._memesuite_version}, motifs={self._motifs}, alphabet={self._alphabet}, background_frequencies={self._background_frequencies}, strands={self._strands})"
+
+
+def array_to_string(array: np.ndarray, precision: int) -> str:
+	"""Convert a 2D numpy array to a string with the given precision."""
+	# create a format string with the desired precision
+	float_formatter = "{:." + str(precision) + "f}"
+	
+	# manually format each float in the array and join them with spaces
+	string_rows = [" ".join(float_formatter.format(x) for x in row) for row in array]
+
+	# join rows with line breaks to retain 2D structure
+	return "\n".join(string_rows)

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -1,0 +1,134 @@
+# Create a class that can be used to write MEME files.
+from typing import List, Optional
+import numpy as np
+
+class MemeWriterMotif:
+	"""Class for handling Motif for MEME file writing."""
+
+	def __init__(
+		self,
+		name: str,
+		probability_matrix: np.ndarray,
+		# `alphabet_length` is known as 'alength' in MEME Suite.
+		alphabet_length: int,
+		# `source_sites` is known as 'nsites' in MEME Suite.
+		source_sites: int,
+		e_value: Optional[str] = None,
+		url: Optional[str] = None
+	) -> None:
+		self._name = name
+		self._probability_matrix = probability_matrix
+		self._alphabet_length = alphabet_length
+		self._source_sites = source_sites
+		self._e_value = e_value
+		self._url = url
+
+	@property
+	def name(self):
+		return self._name
+
+	@property
+	def probability_matrix(self):
+		return self._probability_matrix
+
+	@property
+	def alphabet_length(self):
+		return self._alphabet_length
+	
+	@property
+	def source_sites(self):
+		return self._source_sites
+
+	@property
+	def e_value(self):
+		return self._e_value
+
+	@property
+	def url(self):
+		return self._url
+
+	def __repr__(self) -> str:
+		return f"MemeWriterMotif(name={self._name})"
+
+
+class MemeWriter:
+	"""Class for handling MEME file writing."""
+
+	def __init__(
+		self,
+		memesuite_version: str,
+		# May also be added incrementally using `add_motif()`.
+		motifs: List[MemeWriterMotif] = [],
+		# Optional (Recommended) by MEME Suite.
+		alphabet: Optional[str] = None,
+		background_frequencies: Optional[str] = None,
+		background_frequencies_source: Optional[str] = None,
+		# Optional by MEME Suite.
+		strands: Optional[List[str]] = None,
+	) -> None:
+		self._memesuite_version = memesuite_version
+		self._motifs = motifs if motifs is not None else []
+		# Alphabet example: "ACGT".
+		self._alphabet = alphabet
+		# Background frequncies example: "A 0.25 C 0.25 G 0.25 T 0.25".
+		self._background_frequencies = background_frequencies
+		self._background_frequencies_source = background_frequencies_source
+		# Strands example: "+ -".
+		self._strands = strands
+
+	@property
+	def memesuite_version(self):
+		return self._memesuite_version
+
+	@property
+	def motifs(self):
+		return self._motifs
+	
+	@property
+	def alphabet(self):
+		return self._alphabet
+	
+	@property
+	def background_frequencies(self):
+		return self._background_frequencies
+
+	@property
+	def background_frequencies_source(self):
+		return self._background_frequencies_source
+	
+	@property
+	def strands(self):
+		return self._strands
+
+	def add_motif(self, motif: MemeWriterMotif) -> None:
+		self._motifs.append(motif)
+
+	def write(self, file_path: str) -> None:
+		output = ""
+		output += f"MEME version {self._memesuite_version}\n\n"
+		if self._alphabet:
+			output += f"ALPHABET= {self._alphabet}\n\n"
+		if self._strands:
+			output += f"strands: {self._strands}\n\n"
+		if self._background_frequencies:
+			output += f"Background letter frequencies"
+			if self._background_frequencies_source:
+				output += f" (from {self._background_frequencies_source}):"
+			output += "\n"
+			output += f"{self._background_frequencies}\n\n"
+		for motif in self._motifs:
+			output += f"MOTIF {motif.name}\n"
+			output += f"letter-probability matrix: alength= {str(motif.alphabet_length)} w= {motif.probability_matrix.shape[0]} nsites= {str(motif.source_sites)}"
+			if motif.e_value:
+ 				output += f"E= {motif.e_value}"
+			output += "\n"
+			# Iterate through rows in nparray
+			for row in motif.probability_matrix:
+				output += " ".join([str(x) for x in row])
+			output += "\n"
+			if motif.url:
+				output += f"URL {motif.url}"
+	
+
+	def __repr__(self) -> str:
+		return f"MemeWriter(memesuite_version={self._memesuite_version}, motifs={self._motifs}, alphabet={self._alphabet}, background_frequencies={self._background_frequencies}, strands={self._strands})"

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from os import PathLike
 
-class MemeWriterMotif:
+class MEMEWriterMotif:
 	"""Class for handling Motif for MEME file writing."""
 
 	def __init__(
@@ -51,7 +51,7 @@ class MemeWriterMotif:
 		return self._url
 
 	def __repr__(self) -> str:
-		return f"MemeWriterMotif(name={self._name})"
+		return f"MEMEWriterMotif(name={self._name})"
 
 	def __str__(self) -> str:
 		output = (f'''\
@@ -64,14 +64,14 @@ letter-probability matrix: alength= {str(self.alphabet_length)} w= {self.probabi
 
 
 
-class MemeWriter:
+class MEMEWriter:
 	"""Class for handling MEME file writing."""
 
 	def __init__(
 		self,
 		memesuite_version: str,
 		# May also be added incrementally using `add_motif()`.
-		motifs: List[MemeWriterMotif] = [],
+		motifs: List[MEMEWriterMotif] = [],
 		# Optional (Recommended) by MEME Suite.
 		alphabet: Optional[str] = None,
 		background_frequencies: Optional[str] = None,
@@ -113,7 +113,7 @@ class MemeWriter:
 	def strands(self):
 		return self._strands
 
-	def add_motif(self, motif: MemeWriterMotif) -> None:
+	def add_motif(self, motif: MEMEWriterMotif) -> None:
 		self._motifs.append(motif)
 
 	def write(self, file_path: PathLike) -> None:
@@ -143,7 +143,7 @@ class MemeWriter:
 	
 
 	def __repr__(self) -> str:
-		return f"MemeWriter(memesuite_version={self._memesuite_version}, motifs={self._motifs}, alphabet={self._alphabet}, background_frequencies={self._background_frequencies}, strands={self._strands})"
+		return f"MEMEWriter(memesuite_version={self._memesuite_version}, motifs={self._motifs}, alphabet={self._alphabet}, background_frequencies={self._background_frequencies}, strands={self._strands})"
 
 
 def array_to_string(array: np.ndarray, precision: int) -> str:

--- a/modiscolite/meme_writer.py
+++ b/modiscolite/meme_writer.py
@@ -2,6 +2,8 @@
 from typing import List, Optional
 import numpy as np
 
+from os import PathLike
+
 class MemeWriterMotif:
 	"""Class for handling Motif for MEME file writing."""
 
@@ -103,7 +105,19 @@ class MemeWriter:
 	def add_motif(self, motif: MemeWriterMotif) -> None:
 		self._motifs.append(motif)
 
-	def write(self, file_path: str) -> None:
+	def write(self, file_path: PathLike) -> None:
+
+		def array_to_string(array: np.ndarray, precision: int) -> str:
+			"""Convert a 2D numpy array to a string with the given precision."""
+			# create a format string with the desired precision
+			float_formatter = "{:." + str(precision) + "f}"
+			
+			# manually format each float in the array and join them with spaces
+			string_rows = [" ".join(float_formatter.format(x) for x in row) for row in array]
+
+			# join rows with line breaks to retain 2D structure
+			return "\n".join(string_rows)
+
 		output = ""
 		output += f"MEME version {self._memesuite_version}\n\n"
 		if self._alphabet:
@@ -123,11 +137,19 @@ class MemeWriter:
  				output += f"E= {motif.e_value}"
 			output += "\n"
 			# Iterate through rows in nparray
-			for row in motif.probability_matrix:
-				output += " ".join([str(x) for x in row])
+			output += array_to_string(motif.probability_matrix, 6)
 			output += "\n"
 			if motif.url:
-				output += f"URL {motif.url}"
+				output += f"URL {motif.url}\n"
+			output += "\n"
+		try:
+			# Open the file in write mode
+			with open(file_path, "w") as file:
+				# Write the string to the file
+				file.write(output)
+			print(f"Successfully wrote to the file {file_path}.")
+		except IOError:
+			print(f"An error occurred while writing to the file {file_path}.")
 	
 
 	def __repr__(self) -> str:

--- a/modiscolite/util.py
+++ b/modiscolite/util.py
@@ -2,8 +2,26 @@
 # Authors: Jacob Schreiber <jmschreiber91@gmail.com>
 # adapted from code written by Avanti Shrikumar 
 
+from enum import Enum
 import numpy as np
 from numba import njit
+
+
+class MemeDataType(Enum):
+	PFM = "pfm"
+	CWM = "cwm"
+	hCWM = "hcwm"
+	CWM_PFM = "cwm-pfm"
+	hCWM_PFM = "hcwm-pfm"
+
+	def __str__(self):
+		return self.value
+
+
+def case_insensitive_meme_datatype(arg_str):
+	arg_str = arg_str.lower()
+	return MemeDataType(arg_str)
+
 
 def cpu_sliding_window_sum(arr, window_size):
 	to_return = np.zeros(len(arr)-window_size+1)

--- a/modiscolite/util.py
+++ b/modiscolite/util.py
@@ -1,5 +1,5 @@
 # util.py
-# Authors: Jacob Schreiber <jmschreiber91@gmail.com>
+# Authors: Jacob Schreiber <jmschreiber91@gmail.com>, Ivy Raine <ivy.ember.raine@gmail.com>
 # adapted from code written by Avanti Shrikumar 
 
 from enum import Enum

--- a/modiscolite/util.py
+++ b/modiscolite/util.py
@@ -8,19 +8,15 @@ from numba import njit
 
 
 class MemeDataType(Enum):
-	PFM = "pfm"
-	CWM = "cwm"
-	hCWM = "hcwm"
-	CWM_PFM = "cwm-pfm"
-	hCWM_PFM = "hcwm-pfm"
+	PFM = "PFM"
+	CWM = "CWM"
+	hCWM = "hCWM"
+	CWM_PFM = "CWM-PFM"
+	hCWM_PFM = "hCWM-PFM"
 
 	def __str__(self):
 		return self.value
 
-
-def case_insensitive_meme_datatype(arg_str):
-	arg_str = arg_str.lower()
-	return MemeDataType(arg_str)
 
 
 def cpu_sliding_window_sum(arr, window_size):


### PR DESCRIPTION
- Fixes #23 
- This PR implements several ways of writing MEME files (not all of them are "canon" to the MEME spec, such as the CWM variation). The options are as follows:
  - 'PFM':      The position-frequency matrix.
  - 'CWM':      The contribution-weight matrix.
  - 'hCWM':     The hypothetical contribution-weight matrix; hypothetical
                contribution scores are the contributions of nucleotides not encoded
                by the one-hot encoding sequence. 
  - 'CWM-PFM':  The softmax of the contribution-weight matrix.
  - 'hCWM-PFM': The softmax of the hypothetical contribution-weight matrix.

