### PR TITLE
build: Remove upper bound on requires-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
 	author='Jacob Schreiber',
 	author_email='jmschreiber91@gmail.com',
 	packages=['modiscolite'],
-	python_requires='>=3.7, <3.11',
+	python_requires='>=3.7',
 	scripts=['modisco'],
 	url='https://github.com/jmschrei/tfmodisco-lite',
 	license='LICENSE.txt',


### PR DESCRIPTION
Remove upper bound on requires-python as advocated for in Henry Schreiner's blog post "Should You Use Upper Bound Version Constraints?".
   - c.f. https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special

c.f. https://github.com/poliastro/poliastro/pull/1588 for reference