### PR TITLE
Print useful error message when `tomtom` is missing

### DIFF
--- a/modiscolite/report.py
+++ b/modiscolite/report.py
@@ -107,7 +107,7 @@ def fetch_tomtom_matches(ppm, cwm, is_writing_tomtom_matrix, output_dir,
 	write_meme_file(trimmed, background, fname)
 
 	if not os.path.isfile(tomtom_exec_path):
-		raise ValueError(f'`tomtom` executable not found at expected path: "{tomtom_exec_path}". Please install it and try again.')
+		raise ValueError(f'`tomtom` executable not found at expected path: "{tomtom_exec_path}". Please install it and try again. You may install it using conda with `conda install -c bioconda meme`')
 
 	# run tomtom
 	cmd = '%s -no-ssc -oc . --verbosity 1 -text -min-overlap 5 -mi 1 -dist pearson -evalue -thresh 10.0 %s %s > %s' % (tomtom_exec_path, fname, motifs_db, tomtom_fname)

--- a/modiscolite/report.py
+++ b/modiscolite/report.py
@@ -106,6 +106,9 @@ def fetch_tomtom_matches(ppm, cwm, is_writing_tomtom_matrix, output_dir,
 	# trim and prepare meme file
 	write_meme_file(trimmed, background, fname)
 
+	if not os.path.isfile(tomtom_exec_path):
+		raise ValueError(f'`tomtom` executable not found at expected path: "{tomtom_exec_path}". Please install it and try again.')
+
 	# run tomtom
 	cmd = '%s -no-ssc -oc . --verbosity 1 -text -min-overlap 5 -mi 1 -dist pearson -evalue -thresh 10.0 %s %s > %s' % (tomtom_exec_path, fname, motifs_db, tomtom_fname)
 	os.system(cmd)

--- a/modiscolite/report.py
+++ b/modiscolite/report.py
@@ -6,6 +6,7 @@ from typing import List, Union
 import h5py
 import pandas
 import tempfile
+import shutil
 
 import matplotlib
 matplotlib.use('pdf')
@@ -106,8 +107,8 @@ def fetch_tomtom_matches(ppm, cwm, is_writing_tomtom_matrix, output_dir,
 	# trim and prepare meme file
 	write_meme_file(trimmed, background, fname)
 
-	if not os.path.isfile(tomtom_exec_path):
-		raise ValueError(f'`tomtom` executable not found at expected path: "{tomtom_exec_path}". Please install it and try again. You may install it using conda with `conda install -c bioconda meme`')
+	if not shutil.which(tomtom_exec_path):
+		raise ValueError(f'`tomtom` executable could not be called globally or locally. Please install it and try again. You may install it using conda with `conda install -c bioconda meme`')
 
 	# run tomtom
 	cmd = '%s -no-ssc -oc . --verbosity 1 -text -min-overlap 5 -mi 1 -dist pearson -evalue -thresh 10.0 %s %s > %s' % (tomtom_exec_path, fname, motifs_db, tomtom_fname)


### PR DESCRIPTION
This prints error message when `tomtom` is missing. This is can be shown in the `bpnet pipeline` output:
```
bpnet pipeline -p example_jsons/bpnet_pipeline_example.json
...
Step 5: TF-MoDISco reports
Traceback (most recent call last):
  File "/users/airanman/.local/bin/modisco", line 215, in <module>
    modiscolite.report.report_motifs(args.h5py, args.output,
  File "/users/airanman/.local/lib/python3.10/site-packages/modiscolite/report.py", line 284, in report_motifs
    tomtom_df = generate_tomtom_dataframe(modisco_h5py, output_dir, meme_motif_db,
  File "/users/airanman/.local/lib/python3.10/site-packages/modiscolite/report.py", line 156, in generate_tomtom_dataframe
    r = fetch_tomtom_matches(ppm, cwm,
  File "/users/airanman/.local/lib/python3.10/site-packages/modiscolite/report.py", line 110, in fetch_tomtom_matches
    raise ValueError(f'`tomtom` executable not found at expected path: "{tomtom_exec_path}". Please install it and try again.')
ValueError: `tomtom` executable not found at expected path: "tomtom". Please install it and try again. You may install it using conda with `conda install -c bioconda meme`
...
```
Fixes https://github.com/jmschrei/bpnet-lite/issues/2