### PR TITLE
Do not modify global matplotlib settings

### DIFF
--- a/modiscolite/report.py
+++ b/modiscolite/report.py
@@ -1,14 +1,10 @@
 import os
 import h5py
-import types
-import pickle
 import pandas
 import shutil
 import tempfile
 import logomaker
 
-import matplotlib
-matplotlib.use('pdf')
 from matplotlib import pyplot as plt
 
 import numpy as np


### PR DESCRIPTION
@jmschrei @bytewife 

This PR fixes #53 which reports this exact same issue

I run into the same problem: I import `modiscolite` in a Jupyter Notebook and my figures don't show up anymore as they used to.

As workaround `%matplotlib inline` can be executed in a Jupyter cell, but that is only after you know what the problem is. Took me a while to debug and then find #53.

In general, it is not a good idea to modify global settings of other python packages (matplotlib in this case) without the user explicitly running something.

From searching the code base it seems that the only place where figures are saved is the `_plot_weights` function which is invoked only with `.png` file paths, so I suppose there is really no need to execute ` matplotlib.use('pdf')`.